### PR TITLE
Fix homepage and icon URLs in the Extensions Manager in Slicer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,12 @@ project(SlicerNetstim)
 
 #-----------------------------------------------------------------------------
 # Extension meta-information
-set(EXTENSION_HOMEPAGE "https://www.slicer.org/wiki/Documentation/Nightly/Extensions/SlicerNetstim")
+set(EXTENSION_HOMEPAGE "https://github.com/netstim/SlicerNetstim")
 set(EXTENSION_CATEGORY "Netstim")
 set(EXTENSION_CONTRIBUTORS "Simon Oxenford (Charite Berlin)")
 set(EXTENSION_DESCRIPTION "Netstim modules collection")
-set(EXTENSION_ICONURL "http://www.example.com/Slicer/Extensions/SlicerNetstim.png")
-set(EXTENSION_SCREENSHOTURLS "http://www.example.com/Slicer/Extensions/SlicerNetstim/Screenshots/1.png")
+set(EXTENSION_ICONURL "https://raw.githubusercontent.com/netstim/SlicerNetstim/master/logo.png")
+set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/netstim/SlicerNetstim/master/Documentation/Screenshot.png")
 set(EXTENSION_DEPENDS "NA") # Specified as a list or "NA" if no dependencies
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
The Extensions Manager in Slicer uses URLs in this CMakeLists.txt file.