### PR TITLE
STYLE: Upgrade python syntax to 3.9 and newer

### DIFF
--- a/ImportAtlas/ImportAtlas.py
+++ b/ImportAtlas/ImportAtlas.py
@@ -91,7 +91,7 @@ class ImportAtlasWidget(ScriptedLoadableModuleWidget):
 
   def onImportButton(self):
     leadDBSPath = slicer.util.settingsValue("NetstimPreferences/leadDBSPath", "", converter=str)
-    if leadDBSPath is "": return
+    if leadDBSPath == "": return
     atlasPath = os.path.join(leadDBSPath, 'templates', 'space', 'MNI152NLin2009bAsym', 'atlases', self.atlasComboBox.currentText)
     logic = ImportAtlasLogic()
     qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)
@@ -117,7 +117,7 @@ class ImportAtlasLogic(ScriptedLoadableModuleLogic):
 
   def getValidAtlases(self):
     leadDBSPath = slicer.util.settingsValue("NetstimPreferences/leadDBSPath", "", converter=str)
-    if leadDBSPath is "": return
+    if leadDBSPath == "": return
     import glob
     validAtlases = glob.glob(os.path.join(leadDBSPath, 'templates', 'space', 'MNI152NLin2009bAsym', 'atlases', '*', 'atlas_index.mat'))
     if not validAtlases:
@@ -181,7 +181,7 @@ class ImportAtlasLogic(ScriptedLoadableModuleLogic):
 # Atlas Structure
 #
 
-class LeadDBSAtlasStructure(object):
+class LeadDBSAtlasStructure:
   def __init__(self):
     self.atlasPath = None
     self.index = None
@@ -362,7 +362,7 @@ class DiscFibersStructure(FibersStructure):
 # Lead-DBS Atlas
 #
 
-class LeadDBSAtlas(object):
+class LeadDBSAtlas:
   def __init__(self, atlasPath):
 
     try:

--- a/LeadOR/LeadORLib/util.py
+++ b/LeadOR/LeadORLib/util.py
@@ -79,7 +79,7 @@ class Trajectory(VTKObservationMixin):
       self.RMSNode = slicer.cli.run(slicer.modules.rootmeansquare, None, {'dataFileName': self.alphaOmegaChannelNode.GetChannelFullSavePath()})
       self.addObserver(self.RMSNode, slicer.vtkMRMLCommandLineModuleNode.StatusModifiedEvent, self.onRMSModified)
     if hasattr(slicer.modules,'matlabcommander'):
-      initCommand = 'addpath("' + os.path.dirname(os.path.abspath(__file__)) + '");addpath(genpath("' + os.path.join(os.path.expanduser('~'),'Documents','MATLAB','wave_clus') + '"))'
+      initCommand = 'addpath("' + os.path.dirname(__file__) + '");addpath(genpath("' + os.path.join(os.path.expanduser('~'),'Documents','MATLAB','wave_clus') + '"))'
       self.WCNode = slicer.cli.run(slicer.modules.matlabcommander, None, {'cmd':initCommand})
       self.addObserver(self.WCNode, slicer.vtkMRMLCommandLineModuleNode.StatusModifiedEvent, self.onWCModified)
 

--- a/NetstimPreferences/NetstimPreferences.py
+++ b/NetstimPreferences/NetstimPreferences.py
@@ -38,7 +38,7 @@ class NetstimPreferencesSettingsPanel(ctk.ctkSettingsPanel):
     self.ui = NetstimPreferencesSettingsUI(self)
 
 
-class NetstimPreferencesSettingsUI(object):
+class NetstimPreferencesSettingsUI:
   def __init__(self, parent):
       layout = qt.QFormLayout(parent)
 

--- a/SlicerNetstimLib/util.py
+++ b/SlicerNetstimLib/util.py
@@ -118,7 +118,7 @@ class LeadDBSSubject():
 
   def getModalityFromSeriesDescription(self, seriesDescription):
     for g in glob.glob(os.path.join(self.path, 'anat_*.nii')):
-      modality = re.search('(?<=anat_)\w+', g).group(0)
+      modality = re.search(r'(?<=anat_)\w+', g).group(0)
       if modality.lower() in seriesDescription.lower():
         return modality
     return 't1'

--- a/StereotacticPlan/StereotacticPlanLib/util.py
+++ b/StereotacticPlan/StereotacticPlanLib/util.py
@@ -64,13 +64,13 @@ class StereotaxyReport():
 
   def getCoordinates(self, queryPoint, queryCoordinateSystem, outCoordinateSystem=None):
     # define crop bounding box and transform to RAS
-    if queryCoordinateSystem is 'Headring':
+    if queryCoordinateSystem == 'Headring':
       cropBoundingBox = (0, self.pdfHeight * 0.57 , self.pdfWidth/2, self.pdfHeight * 0.85)     
       toRAS = np.array([[ -1,  0,  0,  100],
                         [  0,  1,  0, -100],
                         [  0,  0, -1,  100],
                         [  0,  0,  0,    1]])
-    elif queryCoordinateSystem is 'DICOM':
+    elif queryCoordinateSystem == 'DICOM':
       cropBoundingBox = (self.pdfWidth/2, self.pdfHeight * 0.57 , self.pdfWidth, self.pdfHeight * 0.85)  
       toRAS = np.array([[ -1,  0,  0,  0],
                         [  0, -1,  0,  0],
@@ -81,11 +81,11 @@ class StereotaxyReport():
     # extract text
     PDFText = self.pdf.pages[1].crop(cropBoundingBox).extract_text()
     # extract coords
-    m = re.search('(?<=' + queryPoint + ' Point)' + ' [-]?\d+[.]\d+ mm' * 3, PDFText)
+    m = re.search('(?<=' + queryPoint + ' Point)' + r' [-]?\d+[.]\d+ mm' * 3, PDFText)
     xyz_str = m.group(0).split('mm')
     xyz_flt = [float(x) for x in xyz_str[:-1]]
     # transform
-    if outCoordinateSystem is 'RAS':
+    if outCoordinateSystem == 'RAS':
       xyz_flt = np.dot(toRAS, np.append(xyz_flt, 1))[:3]
     return xyz_flt
 
@@ -140,4 +140,3 @@ def setDefaultResliceDriver(transformNode):
     logic.SetModeForSlice(      settings['mode'],   settings['node'])
     logic.SetRotationForSlice(  settings['angle'],  settings['node'])
     logic.SetFlipForSlice(      settings['flip'],   settings['node'])
-      

--- a/WarpDrive/WarpDriveLib/Widgets/TreeView.py
+++ b/WarpDrive/WarpDriveLib/Widgets/TreeView.py
@@ -7,7 +7,7 @@ import WarpDrive, ImportAtlas
 
 from ..Helpers import WarpDriveUtil
 
-class treeViewFilter(object):
+class treeViewFilter:
 
   def __init__(self):
     # defaults
@@ -137,7 +137,7 @@ class treeViewAtlasFilter(treeViewFilter):
 
   def addFunction(self):
     leadDBSPath = slicer.util.settingsValue("NetstimPreferences/leadDBSPath", "", converter=str)
-    if leadDBSPath is "":
+    if leadDBSPath == "":
       qt.QMessageBox().warning(qt.QWidget(), "", "Add Lead-DBS path to Slicer preferences")
       return
     validAtlasesNames = ImportAtlas.ImportAtlasLogic().getValidAtlases()


### PR DESCRIPTION
Some syntax upgrading is necessary for SlicerNetSim as I noticed in https://slicer.cdash.org/viewBuildError.php?buildid=2581756 that there were syntax warnings. These warnings are present because Slicer recently upgrade from Python 3.6.7 to Python 3.9.10 in https://github.com/Slicer/Slicer/commit/34e48e8aef5dad19ec8a955d6f48a1940846e3f3.

The syntax warning in question started as of Python 3.8.
https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-python-behavior

> The compiler now produces a [SyntaxWarning](https://docs.python.org/3.8/library/exceptions.html#SyntaxWarning) when identity checks (is and is not) are used with certain types of literals (e.g. strings, numbers). These can often work by accident in CPython, but are not guaranteed by the language spec. The warning advises users to use equality tests (== and !=) instead. (Contributed by Serhiy Storchaka in [bpo-34850](https://bugs.python.org/issue34850).)

This PR uses [`pyupgrade`](https://github.com/asottile/pyupgrade) to automatically upgrade python syntax to newer versions. The script listed below was run for Python 3.6+ syntax with changes committed, followed by Python 3.7+, then Python 3.8+ and finally Python 3.9+.  There were no changes made when specifying Python 3.7+ or 3.8+ which is why there are no commits for those iterations.

## Using pyupgrade

- Install: `PythonSlicer -m pip install pyupgrade`
- Running:
  - On 1 file: `PythonSlicer -m pyupgrade --py36-plus MyPythonFile.py`
  - On multiple files: Here is my pyupgrade-script.py written to automate running pyupgrade across all python files in the Slicer repo. It was run by `PythonSlicer pyupgrade-script.py`.
```python
# pyupgrade-script.py
import os
import subprocess

search_directory = "C:/Users/JamesButler/Documents/GitHub/SlicerNetstim"
for root, _, files in os.walk(search_directory):
    for file_item in files:
        file_path = os.path.join(root, file_item)
        if os.path.isfile(file_path) and file_path.endswith(".py"):
            subprocess.call(["PythonSlicer", "-m", "pyupgrade", "--py36-plus", file_path])
```

cc: @simonoxen for review